### PR TITLE
Fixed memory leak for cmap_ctx variable

### DIFF
--- a/lib/fosphor/gl_cmap.c
+++ b/lib/fosphor/gl_cmap.c
@@ -217,6 +217,8 @@ fosphor_gl_cmap_release(struct fosphor_gl_cmap_ctx *cmap_ctx)
 	gl_cmap_release_shader(&cmap_ctx->shaders[GL_CMAP_SHADER_SIMPLE]);
 	gl_cmap_release_shader(&cmap_ctx->shaders[GL_CMAP_SHADER_BICUBIC]);
 	gl_cmap_release_shader(&cmap_ctx->shaders[GL_CMAP_SHADER_FALLBACK]);
+
+	free(cmap_ctx);
 }
 
 


### PR DESCRIPTION
It seems like the _cmap_ctx_ variable in _gl_cmap.c_ never is freed.