### PR TITLE
Add a check for clCreateImage support during device selection

### DIFF
--- a/lib/fosphor/cl.c
+++ b/lib/fosphor/cl.c
@@ -58,6 +58,7 @@ struct fosphor_cl_features
 #define FLG_CL_NVIDIA_SM11	(1<<1)
 #define FLG_CL_OPENCL_11	(1<<2)
 #define FLG_CL_LOCAL_ATOMIC_EXT	(1<<3)
+#define FLG_CL_IMAGE		(1<<4)
 
 	cl_device_type type;
 	char vendor[128];
@@ -148,6 +149,15 @@ cl_device_query(cl_device_id dev_id, struct fosphor_cl_features *feat)
 	if (err != CL_SUCCESS)
 		return -1;
 
+	/* Image support */
+	cl_bool image_support;
+	err = clGetDeviceInfo(dev_id, CL_DEVICE_IMAGE_SUPPORT, sizeof(image_support), &image_support, NULL);
+	if (err != CL_SUCCESS)
+		return -1;
+
+	if (image_support == CL_TRUE)
+		feat->flags |= FLG_CL_IMAGE;
+
 	/* CL/GL extension */
 	err = clGetDeviceInfo(dev_id, CL_DEVICE_EXTENSIONS, sizeof(txt)-1, txt, NULL);
 	if (err != CL_SUCCESS)
@@ -228,6 +238,10 @@ cl_device_score(cl_device_id dev_id, struct fosphor_cl_features *feat)
 
 	/* Check compatibility */
 	if (!(feat->flags & (FLG_CL_NVIDIA_SM11 | FLG_CL_OPENCL_11 | FLG_CL_LOCAL_ATOMIC_EXT)))
+		return -1;
+
+	/* Image support is required */
+	if (!(feat->flags & FLG_CL_IMAGE))
 		return -1;
 
 	/* Prefer device with CL/GL sharing */


### PR DESCRIPTION
My new laptop running the Mesa drivers for my AMD GPU includes OpenCL 1.1 but does not support the clCreateImage command. Thus, I have installed the Intel CPU driver instead. However, with both of them installed, fosphor still tries to use the GPU because it would theoretically be faster, and then fails. I added an explicit check for Image support to avoid the GPU in this case since its OpenCL support is insufficient, thus allowing the switchover to CPU.

Perhaps a better long-term solution would be a command-line parameter to explicitly pick a device, but I'm not sure how that would work through other frontends.