### PR TITLE
qt and cmake 4 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(gr-fosphor CXX C)
 include(GNUInstallDirs)
 enable_testing()
@@ -91,7 +91,7 @@ set(GR_PKG_LIBEXEC_DIR  ${GR_LIBEXEC_DIR}/${CMAKE_PROJECT_NAME})
 ########################################################################
 # Find boost
 ########################################################################
-find_package(Boost "1.65" COMPONENTS system chrono thread)
+find_package(Boost "1.65" COMPONENTS chrono thread)
 
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost required to compile gr-fosphor")

--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -54,10 +54,11 @@ endmacro(GR_PYBIND_MAKE)
 
 list(APPEND fosphor_python_files
     base_sink_c_python.cc
-    glfw_sink_c_python.cc
-    qt_sink_c_python.cc
     overlap_cc_python.cc
     python_bindings.cc)
+
+  list_cond_append(ENABLE_GLFW fosphor_python_files glfw_sink_c_python.cc)
+  list_cond_append(ENABLE_QT5  fosphor_python_files qt_sink_c_python.cc)
 
 GR_PYBIND_MAKE(fosphor
    ../..

--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -58,7 +58,7 @@ list(APPEND fosphor_python_files
     python_bindings.cc)
 
   list_cond_append(ENABLE_GLFW fosphor_python_files glfw_sink_c_python.cc)
-  list_cond_append(ENABLE_QT5  fosphor_python_files qt_sink_c_python.cc)
+  list_cond_append(ENABLE_QT fosphor_python_files qt_sink_c_python.cc)
 
 GR_PYBIND_MAKE(fosphor
    ../..


### PR DESCRIPTION
This is required for newer cmake compatibility. 

Also included a patch from [Thomas Beierlein](https://github.com/dl1jbe) to optionally disable the outdated qt component as well as the glfw component.